### PR TITLE
(@uoguelph/web-components) Adjust sub navigation height for long page-title in uofg-header

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,5 +101,5 @@ You can then merge your PR, switch to the main branch,
 pull the changes, and publish the packages using the following command:
 
 ```sh
-lerna publish from-git --no-private --pre-dist-tag rc
+lerna publish from-package --no-private --pre-dist-tag rc
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -15487,7 +15487,7 @@
     },
     "packages/web-components": {
       "name": "@uoguelph/web-components",
-      "version": "2.0.3",
+      "version": "2.0.4-rc.0",
       "license": "0BSD",
       "devDependencies": {
         "@fortawesome/free-brands-svg-icons": "^6.4.0",

--- a/packages/storybook/stories/web-components/components/header.stories.tsx
+++ b/packages/storybook/stories/web-components/components/header.stories.tsx
@@ -37,10 +37,7 @@ const config = {
 export default config;
 
 export const Basic = {
-  render: ({}) => (
-    // @ts-expect-error Svelte will define the custom element, so we can ignore the error
-    <uofg-header></uofg-header>
-  ),
+  render: ({}) => <uofg-header></uofg-header>,
 };
 
 export const WithPageTitle = {
@@ -52,10 +49,7 @@ export const WithPageTitle = {
       },
     },
   },
-  render: ({}) => (
-    // @ts-expect-error Svelte will define the custom element, so we can ignore the error
-    <uofg-header page-title="Example Page Title"></uofg-header>
-  ),
+  render: ({}) => <uofg-header page-title="Example Page Title"></uofg-header>,
 };
 
 export const WithPageLink = {
@@ -67,10 +61,7 @@ export const WithPageLink = {
       },
     },
   },
-  render: ({}) => (
-    // @ts-expect-error Svelte will define the custom element, so we can ignore the error
-    <uofg-header page-title="Example Page Title" page-url="#example"></uofg-header>
-  ),
+  render: ({}) => <uofg-header page-title="Example Page Title" page-url="#example"></uofg-header>,
 };
 
 export const WithSubNavigation = {
@@ -83,8 +74,7 @@ export const WithSubNavigation = {
     },
   },
   render: ({}) => (
-    // @ts-expect-error Svelte will define the custom element, so we can ignore the error
-    <uofg-header page-title="Example Topic/Department">
+    <uofg-header page-title="Example Topic/Department" page-url="#example">
       <a href="#example">Example Link</a>
       <a href="#example">Example Link 2</a>
 
@@ -99,7 +89,6 @@ export const WithSubNavigation = {
           <a href="#example">Example Menu Link 3</a>
         </li>
       </ul>
-      {/* @ts-expect-error Svelte will define the custom element, so we can ignore the error */}
     </uofg-header>
   ),
 };
@@ -114,7 +103,6 @@ export const WithOverflowingSubNavigation = {
     },
   },
   render: ({}) => (
-    // @ts-expect-error Svelte will define the custom element, so we can ignore the error
     <uofg-header page-title="Example Topic/Department">
       <a href="#example">Example Link</a>
       <a href="#example">Example Link 2</a>
@@ -134,7 +122,27 @@ export const WithOverflowingSubNavigation = {
       <a href="#example">This is a really long Example Link 3</a>
       <a href="#example">This is a really long Example Link 4</a>
       <a href="#example">This is a really long Example Link 5</a>
-      {/* @ts-expect-error Svelte will define the custom element, so we can ignore the error */}
+    </uofg-header>
+  ),
+};
+
+export const WithLongPageTitle = {
+  render: ({}) => (
+    <uofg-header page-title="Example Topic/Department With a Really Really Really Really Long Name" page-url="#example">
+      <a href="#example">Example Link</a>
+      <a href="#example">Example Link 2</a>
+
+      <ul data-title="Example Menu">
+        <li>
+          <a href="#example">Example Menu Link 1</a>
+        </li>
+        <li>
+          <a href="#example">This is a really long Example Menu Link 2</a>
+        </li>
+        <li>
+          <a href="#example">Example Menu Link 3</a>
+        </li>
+      </ul>
     </uofg-header>
   ),
 };
@@ -148,8 +156,5 @@ export const DualBrand = {
       },
     },
   },
-  render: ({}) => (
-    // @ts-expect-error Svelte will define the custom element, so we can ignore the error
-    <uofg-header page-title="Example Topic/Department" variant="dual-brand"></uofg-header>
-  ),
+  render: ({}) => <uofg-header page-title="Example Topic/Department" variant="dual-brand"></uofg-header>,
 };

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "2.0.3",
+  "version": "2.0.4-rc.0",
   "description": "University of Guelph Web Components Library",
   "type": "module",
   "files": [

--- a/packages/web-components/src/components/uofg-header/sub-navigation/mobile.svelte
+++ b/packages/web-components/src/components/uofg-header/sub-navigation/mobile.svelte
@@ -13,7 +13,7 @@
   <Menu class="h-full" autoCollapse={false}>
     {#snippet button()}
       <MenuButton
-        class="flex aspect-square h-full items-center justify-center gap-2 px-4 transition-colors hover:bg-yellow hover:text-yellow-contrast focus:bg-yellow focus:text-yellow-contrast aria-expanded:bg-yellow aria-expanded:text-yellow-contrast"
+        class="flex h-full items-center justify-center gap-2 px-4 transition-colors hover:bg-yellow hover:text-yellow-contrast focus:bg-yellow focus:text-yellow-contrast aria-expanded:bg-yellow aria-expanded:text-yellow-contrast"
         label="Sub Navigation Menu"
       >
         <FontAwesomeIcon icon={faBars} />

--- a/packages/web-components/src/components/uofg-header/sub-navigation/sub-navigation.svelte
+++ b/packages/web-components/src/components/uofg-header/sub-navigation/sub-navigation.svelte
@@ -32,30 +32,35 @@
 
 <nav
   class={twJoin(
-    'align-items bg-grey-muted text-grey-muted-contrast relative block justify-end px-[calc((100%-1320px)/2)] text-lg lg:whitespace-nowrap',
-    $headerState?.variant === 'dual-brand' ? 'h-10' : 'h-[5rem] lg:h-10',
+    'align-items bg-grey-muted text-grey-muted-contrast relative block h-fit justify-end px-[calc((100%-1320px)/2)] text-lg lg:h-10 lg:whitespace-nowrap',
   )}
   aria-label="Page Specific"
 >
   <div
-    class="relative flex h-full min-w-full items-center justify-end overflow-y-visible [&>li]:contents"
+    class="relative grid h-full min-w-full grid-cols-[10fr_1fr] items-center justify-end overflow-y-visible lg:flex [&>li]:contents"
     bind:clientWidth={containerWidth}
   >
     {#if title && url}
       <a
-        class="mr-auto flex h-full items-center justify-center px-3 font-bold transition-colors hover:bg-yellow hover:text-yellow-contrast"
+        class="mr-auto flex h-full min-h-[5rem] items-center justify-center px-3 font-bold transition-colors hover:bg-yellow hover:text-yellow-contrast lg:min-h-10"
         href={url}
         bind:clientWidth={titleWidth}
       >
         {title}
       </a>
     {:else if title}
-      <span bind:clientWidth={titleWidth} class="mr-auto flex h-full items-center justify-center px-3 font-bold">
+      <span
+        bind:clientWidth={titleWidth}
+        class="mr-auto flex h-full min-h-[5rem] items-center justify-center px-3 font-bold lg:min-h-10"
+      >
         {title}
       </span>
     {/if}
 
-    <ul class="!static flex h-full w-fit lg:static [&>li]:contents" bind:clientWidth={contentWidth}>
+    <ul
+      class="!static flex h-full min-h-[5rem] w-fit justify-self-end lg:static lg:min-h-10 [&>li]:contents"
+      bind:clientWidth={contentWidth}
+    >
       {#if items?.length > 0}
         {#if $headerState.mode === 'desktop' && (isNaN(overflowWidth) || containerWidth > overflowWidth)}
           <Desktop {items} />


### PR DESCRIPTION
# Summary of changes
When a really long title name is specified for the header web-component, it overflows on narrow viewports. This PR fixes that by allowing the sub navigation height to expand based on the page title.

- [ ] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [ ] My changes are responsive and appear as expected on mobile and desktop views.
- [ ] I have fully read and understood the README
- [ ] I have created a test version of the package following the instructions listed in the readme
- [ ] I have updated any relevant pages in the storybook (under packages/storybook)

# Test Versions
- @uoguelph/tailwind-theme: N/A
- @uoguelph/web-components: 2.0.4-rc.0
- @uoguelph/react-components: N/A

# Test Plan
1. Use test package on gus or ugnext