### PR TITLE
Set lists to be single column by default and remove console log 

### DIFF
--- a/.changeset/kind-queens-remain.md
+++ b/.changeset/kind-queens-remain.md
@@ -1,0 +1,6 @@
+---
+'@uoguelph/react-components': patch
+'@uoguelph/web-components': patch
+---
+
+Update styles in uofg-header: adjust colors for logo segments and set mobile menu button height to 5rem

--- a/.changeset/many-bottles-burn.md
+++ b/.changeset/many-bottles-burn.md
@@ -1,0 +1,6 @@
+---
+'@uoguelph/react-components': patch
+'@uoguelph/web-components': patch
+---
+
+Remove console.log from uofg-header, and remove 'Contact Us' link in news variant of uofg-header

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -8,6 +8,7 @@
     "@uoguelph/web-components": "2.1.0"
   },
   "changesets": [
+    "many-bottles-burn",
     "purple-trams-thank"
   ]
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,13 @@
+{
+  "mode": "pre",
+  "tag": "rc",
+  "initialVersions": {
+    "@uoguelph/react-components": "1.9.0",
+    "@uoguelph/storybook": "1.0.6",
+    "@uoguelph/tailwind-theme": "1.0.2",
+    "@uoguelph/web-components": "2.1.0"
+  },
+  "changesets": [
+    "purple-trams-thank"
+  ]
+}

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -8,6 +8,7 @@
     "@uoguelph/web-components": "2.1.0"
   },
   "changesets": [
+    "kind-queens-remain",
     "many-bottles-burn",
     "purple-trams-thank"
   ]

--- a/.changeset/purple-trams-thank.md
+++ b/.changeset/purple-trams-thank.md
@@ -1,0 +1,5 @@
+---
+'@uoguelph/react-components': patch
+---
+
+Set lists to single column by default

--- a/package-lock.json
+++ b/package-lock.json
@@ -10212,7 +10212,7 @@
     },
     "packages/react-components": {
       "name": "@uoguelph/react-components",
-      "version": "1.9.0-rc.5",
+      "version": "1.9.0",
       "license": "0BSD",
       "devDependencies": {
         "@awesome.me/kit-7993323d0c": "^1.0.11",
@@ -10836,7 +10836,7 @@
     },
     "packages/storybook": {
       "name": "@uoguelph/storybook",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "react": "^19.0.0"
       },
@@ -10891,7 +10891,7 @@
     },
     "packages/web-components": {
       "name": "@uoguelph/web-components",
-      "version": "2.1.0-rc.3",
+      "version": "2.1.0",
       "license": "0BSD",
       "devDependencies": {
         "@fortawesome/free-brands-svg-icons": "^6.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10212,7 +10212,7 @@
     },
     "packages/react-components": {
       "name": "@uoguelph/react-components",
-      "version": "1.9.0",
+      "version": "1.9.1-rc.0",
       "license": "0BSD",
       "devDependencies": {
         "@awesome.me/kit-7993323d0c": "^1.0.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10212,7 +10212,7 @@
     },
     "packages/react-components": {
       "name": "@uoguelph/react-components",
-      "version": "1.9.1-rc.0",
+      "version": "1.9.1-rc.1",
       "license": "0BSD",
       "devDependencies": {
         "@awesome.me/kit-7993323d0c": "^1.0.11",
@@ -10891,7 +10891,7 @@
     },
     "packages/web-components": {
       "name": "@uoguelph/web-components",
-      "version": "2.1.0",
+      "version": "2.1.1-rc.0",
       "license": "0BSD",
       "devDependencies": {
         "@fortawesome/free-brands-svg-icons": "^6.4.0",

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @uoguelph/react-components
 
+## 1.9.1-rc.2
+
+### Patch Changes
+
+- 227b0d8: Update styles in uofg-header: adjust colors for logo segments and set mobile menu button height to 5rem
+
 ## 1.9.1-rc.1
 
 ### Patch Changes

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @uoguelph/react-components
 
+## 1.9.1-rc.0
+
+### Patch Changes
+
+- ad6972f: Set lists to single column by default
+
 ## 1.9.0
 
 ### Minor Changes

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @uoguelph/react-components
 
+## 1.9.1-rc.1
+
+### Patch Changes
+
+- adf45b1: Remove console.log from uofg-header, and remove 'Contact Us' link in news variant of uofg-header
+
 ## 1.9.1-rc.0
 
 ### Patch Changes

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/react-components",
-  "version": "1.9.0",
+  "version": "1.9.1-rc.0",
   "description": "University of Guelph React Components Library",
   "type": "module",
   "scripts": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/react-components",
-  "version": "1.9.1-rc.0",
+  "version": "1.9.1-rc.1",
   "description": "University of Guelph React Components Library",
   "type": "module",
   "scripts": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/react-components",
-  "version": "1.9.1-rc.1",
+  "version": "1.9.1-rc.2",
   "description": "University of Guelph React Components Library",
   "type": "module",
   "scripts": {

--- a/packages/react-components/src/components/list/list.tsx
+++ b/packages/react-components/src/components/list/list.tsx
@@ -21,7 +21,7 @@ export type ListProps<T extends ListElementType = typeof defaultElement> = Props
     /**
      * Whether columns are enabled.
      *
-     * @default true
+     * @default false
      */
     columns?: boolean;
     /** Additional classes to apply to the list. */
@@ -88,7 +88,7 @@ export function List<T extends ListElementType = typeof defaultElement>({
     as: Component,
     level: context.parent === as ? ((context.level % 3) as 0 | 1 | 2 | 3) : 0,
     nested: context.level > 0,
-    columns: columns ?? true,
+    columns: columns ?? false,
   });
 
   return (

--- a/packages/storybook/stories/react-components/list.stories.tsx
+++ b/packages/storybook/stories/react-components/list.stories.tsx
@@ -143,10 +143,10 @@ export const LongList: Story = {
 };
 
 
-export const LongListWithColumnsDisabled: Story = {
+export const LongListWithColumnsEnabled: Story = {
   args: {
     as: 'ul',
-    columns: false,
+    columns: true,
   },
   render: ({ ...args }) => (
     <List {...args}>
@@ -172,6 +172,7 @@ export const LongListWithColumnsDisabled: Story = {
 export const LongListNested: Story = {
   args: {
     as: 'ul',
+    columns: true,
   },
   render: ({ ...args }) => (
       <List {...args}>

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @uoguelph/web-components
 
+## 2.1.1-rc.0
+
+### Patch Changes
+
+- adf45b1: Remove console.log from uofg-header, and remove 'Contact Us' link in news variant of uofg-header
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @uoguelph/web-components
 
+## 2.1.1-rc.1
+
+### Patch Changes
+
+- 227b0d8: Update styles in uofg-header: adjust colors for logo segments and set mobile menu button height to 5rem
+
 ## 2.1.1-rc.0
 
 ### Patch Changes

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "2.1.1-rc.0",
+  "version": "2.1.1-rc.1",
   "description": "University of Guelph Web Components Library",
   "type": "module",
   "files": [

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uoguelph/web-components",
-  "version": "2.1.0",
+  "version": "2.1.1-rc.0",
   "description": "University of Guelph Web Components Library",
   "type": "module",
   "files": [

--- a/packages/web-components/src/components/uofg-header/data/news.ts
+++ b/packages/web-components/src/components/uofg-header/data/news.ts
@@ -21,10 +21,6 @@ export const news: HeaderData = {
       href: 'https://news.uoguelph.ca/events/',
     },
     {
-      text: 'Contact Us',
-      href: 'https://news.uoguelph.ca/media-services/',
-    },
-    {
       text: 'News Directory',
       href: 'https://www.uoguelph.ca/news/directory',
       standalone: true,

--- a/packages/web-components/src/components/uofg-header/primary-navigation/logo.svelte
+++ b/packages/web-components/src/components/uofg-header/primary-navigation/logo.svelte
@@ -54,8 +54,8 @@
     {#if $headerState.data.homepage}
       <div class={line()}>
         <div class={twJoin(lineSegment(), 'bg-red')}></div>
-        <div class={twJoin(lineSegment(), 'bg-red lg:bg-yellow')}></div>
-        <div class={twJoin(lineSegment(), 'bg-red lg:bg-grey-dark')}></div>
+        <div class={twJoin(lineSegment(), 'bg-yellow')}></div>
+        <div class={twJoin(lineSegment(), 'bg-grey-dark')}></div>
       </div>
 
       <a href={$headerState.data.homepage.url} class={secondaryLink()}>{$headerState.data.homepage.text}</a>

--- a/packages/web-components/src/components/uofg-header/primary-navigation/mobile.svelte
+++ b/packages/web-components/src/components/uofg-header/primary-navigation/mobile.svelte
@@ -30,7 +30,7 @@
         <Menu class="h-full w-fit">
           {#snippet button()}
             <MenuButton
-              class="flex aspect-square h-full items-center justify-center gap-2 px-4 transition-colors hover:bg-white hover:text-black focus:bg-white focus:text-black aria-expanded:bg-white aria-expanded:text-black"
+              class="flex aspect-square h-[5rem] items-center justify-center gap-2 px-4 transition-colors hover:bg-white hover:text-black focus:bg-white focus:text-black aria-expanded:bg-white aria-expanded:text-black"
               label={item.text}
             >
               {#if item.icon}
@@ -86,7 +86,7 @@
       <Menu class="h-full w-fit">
         {#snippet button()}
           <MenuButton
-            class="flex aspect-square h-full items-center justify-center gap-2 px-4 transition-colors hover:bg-white hover:text-black focus:bg-white focus:text-black aria-expanded:bg-white aria-expanded:text-black [&_svg]:aria-expanded:rotate-180"
+            class="flex aspect-square h-[5rem] items-center justify-center gap-2 px-4 transition-colors hover:bg-white hover:text-black focus:bg-white focus:text-black aria-expanded:bg-white aria-expanded:text-black [&_svg]:aria-expanded:rotate-180"
             label="Main Menu"
           >
             <FontAwesomeIcon icon={faBars} />

--- a/packages/web-components/src/components/uofg-header/uofg-header.svelte
+++ b/packages/web-components/src/components/uofg-header/uofg-header.svelte
@@ -64,10 +64,6 @@
     }
   });
 
-  $effect(() => {
-    console.log('headerState', $headerState);
-  });
-
   let subNavigation = $state<(HeaderLink | HeaderMenu)[]>([]);
 
   onMount(() => {


### PR DESCRIPTION
# Summary of changes
Set lists to be single column by default
Fix #53 

- Remove console log in uofg-header, and remove 'Contact Us' link in news variant.

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] I have fully read and understood the README
- [x] I have created a test version of the package following the instructions listed in the readme
- [x] I have updated any relevant pages in the storybook (under packages/storybook)

# Test Versions
- @uoguelph/tailwind-theme: x.x.x
- @uoguelph/web-components: x.x.x
- @uoguelph/react-components: x.x.x

# Test Plan
Insert steps.